### PR TITLE
Added jaxb-api dependency for newer java version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
 			<artifactId>commons-lang3</artifactId>
 			<version>3.8</version>
 		</dependency>
+		<dependency>
+		    <groupId>javax.xml.bind</groupId>
+		    <artifactId>jaxb-api</artifactId>
+		    <version>2.3.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Here is the pull request discussed in https://github.com/plantbreeding/brapi-Java-TestServer/issues/37

Simply adding a dependency for newer java versions.