### PR TITLE
[INF-205] - default string type to db text type

### DIFF
--- a/src/main/java/org/brapi/test/BrAPITestServer/model/entity/BrAPIBaseEntity.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/model/entity/BrAPIBaseEntity.java
@@ -5,8 +5,14 @@ import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 
 import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.TypeDef;
+import org.hibernate.type.TextType;
 
 @MappedSuperclass
+@TypeDef(
+	defaultForType = String.class,
+	typeClass = TextType.class
+)
 public class BrAPIBaseEntity {
 
 	@Id


### PR DESCRIPTION
Defaults the java `String` java data type to be created as a `Text` type in the postgres database. 

If you want a `String` to be create in the database as something different, putting a specific type on a property will override the default typing:

```
@Column(columnDefinition="VARCHAR")
private String traitName
```