### PR TITLE
Fix germplasm search

### DIFF
--- a/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/germ/GermplasmService.java
@@ -139,8 +139,8 @@ public class GermplasmService {
 				.appendList(request.getCommonCropNames(), "crop.cropName")
 				.appendList(request.getGenus(), "genus")
 				.appendList(request.getGermplasmDbIds(), "id")
-				.appendList(request.getGermplasmNames(), "name")
-				.appendList(request.getGermplasmPUIs(), "pui")
+				.appendList(request.getGermplasmNames(), "germplasmName")
+				.appendList(request.getGermplasmPUIs(), "germplasmPUI")
 				.appendList(request.getParentDbIds(), "pedigree.parent1.germplasm.id")
 				//.appendList(request.getProgenyDbIds(), "*progeny.germplasmDbId")
 				.appendList(request.getSpecies(), "species");


### PR DESCRIPTION
Germplasm search was returning a 500 error when `germplasmNames` or `germplasmPUI` was specified in the search body. 