### PR TITLE
[BI-1015] - Fix error when setting spring.jpa.hibernate.ddl-auto to "update" in properties file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>9.4-1205-jdbc42</version>
-			<scope>provided</scope>
+			<version>42.1.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
When you set `spring.jpa.hibernate.ddl-auto=update` in the application.properties file it threw an error on start up:

```
org.postgresql.util.PSQLException: ERROR: column am.amcanorder does not exist
```

Found this stack overflow solution: 

https://stackoverflow.com/questions/38427585/postgresql-error-column-am-amcanorder-doesnt-exist

Updating the postgres driver did the trick. For testing, I created a new germplasm, restarted the application, and confirmed it was still there. 